### PR TITLE
Add etcd bump version test

### DIFF
--- a/entrypoint/versionbump/etcd_test.go
+++ b/entrypoint/versionbump/etcd_test.go
@@ -32,12 +32,10 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 	})
 
 	It("Verifies bump version on product for etcd", func() {
-		var cmd string
+		cmd := "sudo journalctl -u k3s | grep 'etcd-version' ," + " k3s -v"
 		if cfg.Product == "rke2" {
 			cmd = "sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock images | grep etcd ," +
 				" rke2 -v"
-		} else {
-			cmd = "sudo journalctl -u k3s | grep 'etcd-version' ," + " k3s -v"
 		}
 
 		template.VersionTemplate(template.VersionTestTemplate{

--- a/entrypoint/versionbump/etcd_test.go
+++ b/entrypoint/versionbump/etcd_test.go
@@ -1,0 +1,70 @@
+//go:build etcd
+
+package versionbump
+
+import (
+	"fmt"
+
+	"github.com/rancher/distros-test-framework/pkg/assert"
+	"github.com/rancher/distros-test-framework/pkg/customflag"
+	"github.com/rancher/distros-test-framework/pkg/template"
+	"github.com/rancher/distros-test-framework/pkg/testcase"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("VersionTemplate Upgrade:", func() {
+	It("Start Up with no issues", func() {
+		testcase.TestBuildCluster(GinkgoT())
+	})
+
+	It("Validate Node", func() {
+		testcase.TestNodeStatus(
+			assert.NodeAssertReadyStatus(),
+			nil)
+	})
+
+	It("Validate Pod", func() {
+		testcase.TestPodStatus(
+			assert.PodAssertRestart(),
+			assert.PodAssertReady(),
+			assert.PodAssertStatus())
+	})
+
+	It("Verifies bump version on product for etcd", func() {
+		var cmd string
+		if cfg.Product == "rke2" {
+			cmd = "sudo /var/lib/rancher/rke2/bin/crictl -r unix:///run/k3s/containerd/containerd.sock images | grep etcd ," +
+				" rke2 -v"
+		} else {
+			cmd = "sudo journalctl -u k3s | grep 'etcd-version' ," + " k3s -v"
+		}
+
+		template.VersionTemplate(template.VersionTestTemplate{
+			TestCombination: &template.RunCmd{
+				Run: []template.TestMap{
+					{
+						Cmd:                  cmd,
+						ExpectedValue:        template.TestMapTemplate.ExpectedValue,
+						ExpectedValueUpgrade: template.TestMapTemplate.ExpectedValueUpgrade,
+					},
+				},
+			},
+			InstallUpgrade: customflag.ServiceFlag.InstallUpgrade,
+			TestConfig: &template.TestConfig{
+				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
+				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
+			},
+			Description: customflag.ServiceFlag.TestConfig.Description,
+		})
+	})
+})
+
+var _ = AfterEach(func() {
+	if CurrentSpecReport().Failed() {
+		fmt.Printf("\nFAILED! %s\n", CurrentSpecReport().FullText())
+	} else {
+		fmt.Printf("\nPASSED! %s\n", CurrentSpecReport().FullText())
+	}
+})

--- a/pkg/template/helper.go
+++ b/pkg/template/helper.go
@@ -9,23 +9,28 @@ import (
 	"github.com/rancher/distros-test-framework/shared"
 )
 
-// upgradeVersion upgrades the version of RKE2 and updates the expected values
+// upgradeVersion upgrades the product version
 func upgradeVersion(template VersionTestTemplate, version string) error {
 	err := testcase.TestUpgradeClusterManually(version)
 	if err != nil {
 		return err
 	}
 
-	for i := range template.TestCombination.Run {
-		template.TestCombination.Run[i].ExpectedValue =
-			template.TestCombination.Run[i].ExpectedValueUpgrade
-	}
+	updateExpectedValue(template)
 
 	return nil
 }
 
-// checkVersion checks the version of RKE2 by calling processTestCombination
-func checkVersion(v VersionTestTemplate) error {
+// updateExpectedValue updates the expected values
+func updateExpectedValue(template VersionTestTemplate) {
+	for i := range template.TestCombination.Run {
+		template.TestCombination.Run[i].ExpectedValue =
+			template.TestCombination.Run[i].ExpectedValueUpgrade
+	}
+}
+
+// executeTestCombination get a template and pass it to `processTestCombination` to execute test combination on group of IPs
+func executeTestCombination(v VersionTestTemplate) error {
 	ips, err := getIPs()
 	if err != nil {
 		return fmt.Errorf("failed to get IPs: %v", err)

--- a/pkg/template/helper.go
+++ b/pkg/template/helper.go
@@ -21,7 +21,7 @@ func upgradeVersion(template VersionTestTemplate, version string) error {
 	return nil
 }
 
-// updateExpectedValue updates the expected values
+// updateExpectedValue updates the expected values getting the values from flag ExpectedValueUpgrade
 func updateExpectedValue(template VersionTestTemplate) {
 	for i := range template.TestCombination.Run {
 		template.TestCombination.Run[i].ExpectedValue =
@@ -31,10 +31,7 @@ func updateExpectedValue(template VersionTestTemplate) {
 
 // executeTestCombination get a template and pass it to `processTestCombination` to execute test combination on group of IPs
 func executeTestCombination(v VersionTestTemplate) error {
-	ips, err := getIPs()
-	if err != nil {
-		return fmt.Errorf("failed to get IPs: %v", err)
-	}
+	ips := shared.FetchNodeExternalIP()
 
 	var wg sync.WaitGroup
 	errorChanList := make(
@@ -58,12 +55,6 @@ func executeTestCombination(v VersionTestTemplate) error {
 	}
 
 	return nil
-}
-
-// getIPs gets the IPs of the nodes
-func getIPs() (ips []string, err error) {
-	ips = shared.FetchNodeExternalIP()
-	return ips, nil
 }
 
 // AddTestCases returns the test case based on the name to be used as customflag.

--- a/pkg/template/processor.go
+++ b/pkg/template/processor.go
@@ -40,19 +40,14 @@ func processCmds(resultChan chan error, wg *sync.WaitGroup, ip string, cmds []st
 func processTestCombination(resultChan chan error, wg *sync.WaitGroup, ips []string, testCombination RunCmd) {
 	if testCombination.Run != nil {
 		for _, testMap := range testCombination.Run {
-
 			cmds := strings.Split(testMap.Cmd, ",")
 			expectedValues := strings.Split(testMap.ExpectedValue, ",")
 
-			ipsToUse := ips
-
 			if strings.Contains(testMap.Cmd, "etcd") {
-
 				cmdToGetIps := fmt.Sprintf(`
 				kubectl get node -A -o wide --kubeconfig="%s" \
 				| grep 'etcd' | awk '{print $7}'
-				`,
-					shared.KubeConfigFile)
+				`, shared.KubeConfigFile)
 
 				var nodes []string
 				nodeIps, err := shared.RunCommandHost(cmdToGetIps)
@@ -67,10 +62,10 @@ func processTestCombination(resultChan chan error, wg *sync.WaitGroup, ips []str
 					}
 				}
 
-				ipsToUse = nodes
+				ips = nodes
 			}
 
-			for _, ip := range ipsToUse {
+			for _, ip := range ips {
 				processCmds(resultChan, wg, ip, cmds, expectedValues)
 			}
 		}

--- a/pkg/template/versiontemplate.go
+++ b/pkg/template/versiontemplate.go
@@ -24,7 +24,7 @@ func VersionTemplate(test VersionTestTemplate) {
 		}
 	}
 
-	err := checkVersion(test)
+	err := executeTestCombination(test)
 	if err != nil {
 		GinkgoT().Errorf(err.Error())
 		return
@@ -43,7 +43,7 @@ func VersionTemplate(test VersionTestTemplate) {
 				return
 			}
 
-			err = checkVersion(test)
+			err = executeTestCombination(test)
 			if err != nil {
 				GinkgoT().Errorf(err.Error())
 				return

--- a/pkg/template/versiontemplate.go
+++ b/pkg/template/versiontemplate.go
@@ -33,7 +33,7 @@ func VersionTemplate(test VersionTestTemplate) {
 	if test.InstallUpgrade != nil {
 		for _, version := range test.InstallUpgrade {
 			if GinkgoT().Failed() {
-				fmt.Println("checkVersion failed, not proceeding to upgrade")
+				fmt.Println("executeTestCombination failed, not proceeding to upgrade")
 				return
 			}
 

--- a/pkg/testcase/upgradecluster.go
+++ b/pkg/testcase/upgradecluster.go
@@ -116,7 +116,7 @@ func upgradeNode(nodeType string, installType string, ips []string) error {
 				close(errCh)
 				return
 			}
-			time.Sleep(20 * time.Second)
+			time.Sleep(40 * time.Second)
 		}(ip, upgradeCommand)
 	}
 	wg.Wait()


### PR DESCRIPTION
Adding `etcd` version bump test.

- Add the etcd version file
- Improvements on `helper` file (change function names & comments)


To test it:
```
# Using upgrade flags -> RKE2 & K3S
go test -timeout=90m -v -tags=etcd ./entrypoint/versionbump/... -expectedValue "3.5.9, v1.26" -expectedValueUpgrade "3.5.9, v1.27" -installVersionOrCommit 000ce7f68fe2f79074d10353a20e9b4f9f3685d9 -channel testing

# Using without upgrade
go test -timeout=95m -v -tags=etcd ./entrypoint/versionbump/... -expectedValue "3.5.9, v1.27"
```