### PR TITLE
Create go-mod-change.yaml

### DIFF
--- a/.github/workflows/go-mod-change.yaml
+++ b/.github/workflows/go-mod-change.yaml
@@ -1,0 +1,76 @@
+name: verify go.mod changes
+
+on: 
+    workflow_dispatch:
+      inputs:
+        target0:
+          description: 'Which release you want to check the go.mod for values.'
+          required: true
+          default: 'master'
+        target1:
+          description: 'The release to compare against the master branch/latest release'
+          required: true
+          default: 'release-1.27'
+        target2:
+          required: false
+        moduleKeyword:
+          description: "The keyword denoting the module you want to check within the go.mod file"
+          required: true
+          default: 'kine'
+    push:
+         branches:
+            - master
+            - release-1.2*
+         paths:
+            - 'go.mod'
+
+jobs:
+    check_goMod:
+        runs-on: ubuntu-latest
+        # runs-on: debian
+        steps:
+        - name: checkout latest
+          uses: actions/checkout@v4
+          with: 
+            repository: 'k3s-io/k3s'
+            ref: '${{ github.event.inputs.target0 }}'
+            sparse-checkout: |
+                go.mod
+            sparse-checkout-cone-mode: false
+        - name: rename go.mod
+          run: |
+            mkdir -p /tmp/comparisons/
+             mv go.mod /tmp/comparisons/go-master.mod
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            repository: 'k3s-io/k3s'
+            ref: "${{ github.event.inputs.target1 }}"
+            sparse-checkout: |
+                go.mod
+            sparse-checkout-cone-mode: false
+        - name: rename go.mod
+          run: |
+               mv go.mod /tmp/comparisons/go-target1.mod
+        - name: Checkout tools repo
+          uses: actions/checkout@v4
+          with:
+            repository: 'k3s-io/k3s'
+            ref: "${{ github.event.inputs.target2 }}"
+            sparse-checkout: |
+                go.mod
+            sparse-checkout-cone-mode: false
+        - name: rename go.mod
+          run: |
+               mv go.mod /tmp/comparisons/go-target2.mod
+        - name: comapre go.mod files
+          run: |
+            target0=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-master.mod)
+            target1=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-target1.mod)
+            target2=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-target2.mod) 
+            echo "The versions present in these go.mod files are below" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target0}" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target1}" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target2}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY 

--- a/.github/workflows/go-mod-change.yaml
+++ b/.github/workflows/go-mod-change.yaml
@@ -27,7 +27,6 @@ on:
 jobs:
     check_goMod:
         runs-on: ubuntu-latest
-        # runs-on: debian
         steps:
         - name: checkout latest
           uses: actions/checkout@v4
@@ -63,7 +62,7 @@ jobs:
         - name: rename go.mod
           run: |
                mv go.mod /tmp/comparisons/go-target2.mod
-        - name: comapre go.mod files
+        - name: compare go.mod files
           run: |
             target0=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-master.mod)
             target1=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-target1.mod)

--- a/.github/workflows/go-mod-change.yaml
+++ b/.github/workflows/go-mod-change.yaml
@@ -35,7 +35,7 @@ jobs:
         - name: checkout latest
           uses: actions/checkout@v4
           with: 
-            repository: '${{github.event.inputs.repo}}'
+            repository: '${{ github.event.inputs.repo }}'
             ref: '${{ github.event.inputs.target0 }}'
             sparse-checkout: |
                 go.mod
@@ -43,37 +43,37 @@ jobs:
         - name: rename go.mod
           run: |
             mkdir -p /tmp/comparisons/
-             mv go.mod /tmp/comparisons/go-master.mod
+             mv go.mod /tmp/comparisons/target0-go.mod
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            repository: '${{github.event.inputs.repo}}'
+            repository: '${{ github.event.inputs.repo }}'
             ref: "${{ github.event.inputs.target1 }}"
             sparse-checkout: |
                 go.mod
             sparse-checkout-cone-mode: false
         - name: rename go.mod
           run: |
-               mv go.mod /tmp/comparisons/go-target1.mod
+               mv go.mod /tmp/comparisons/target1-go.mod
         - name: Checkout tools repo
           uses: actions/checkout@v4
           with:
-            repository: '${{github.event.inputs.repo}}'
+            repository: '${{ github.event.inputs.repo }}'
             ref: "${{ github.event.inputs.target2 }}"
             sparse-checkout: |
                 go.mod
             sparse-checkout-cone-mode: false
         - name: rename go.mod
           run: |
-               mv go.mod /tmp/comparisons/go-target2.mod
+               mv go.mod /tmp/comparisons/target2-go.mod
         - name: compare go.mod files
           run: |
-            target0=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-master.mod)
-            target1=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-target1.mod)
-            target2=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/go-target2.mod) 
+            target0=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/target0-go.mod)
+            target1=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/target1-go.mod)
+            target2=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/target2-go.mod) 
             echo "The versions present in these go.mod files are below" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "- ${target0}" >> $GITHUB_STEP_SUMMARY
-            echo "- ${target1}" >> $GITHUB_STEP_SUMMARY
-            echo "- ${target2}" >> $GITHUB_STEP_SUMMARY
+            echo "- ${ target0 }" >> $GITHUB_STEP_SUMMARY
+            echo "- ${ target1 }" >> $GITHUB_STEP_SUMMARY
+            echo "- ${ target2 }" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY 

--- a/.github/workflows/go-mod-change.yaml
+++ b/.github/workflows/go-mod-change.yaml
@@ -3,6 +3,10 @@ name: verify go.mod changes
 on: 
     workflow_dispatch:
       inputs:
+        repo: 
+          description: 'The repository you want to select ie k3s-io/k3s or rancher/rke2, the default is k3s-io/k3s.'
+          required: false
+          default: 'k3s-io/k3s'
         target0:
           description: 'Which release you want to check the go.mod for values.'
           required: true
@@ -31,7 +35,7 @@ jobs:
         - name: checkout latest
           uses: actions/checkout@v4
           with: 
-            repository: 'k3s-io/k3s'
+            repository: '${{github.event.inputs.repo}}'
             ref: '${{ github.event.inputs.target0 }}'
             sparse-checkout: |
                 go.mod
@@ -43,7 +47,7 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            repository: 'k3s-io/k3s'
+            repository: '${{github.event.inputs.repo}}'
             ref: "${{ github.event.inputs.target1 }}"
             sparse-checkout: |
                 go.mod
@@ -54,7 +58,7 @@ jobs:
         - name: Checkout tools repo
           uses: actions/checkout@v4
           with:
-            repository: 'k3s-io/k3s'
+            repository: '${{github.event.inputs.repo}}'
             ref: "${{ github.event.inputs.target2 }}"
             sparse-checkout: |
                 go.mod

--- a/.github/workflows/go-mod-change.yaml
+++ b/.github/workflows/go-mod-change.yaml
@@ -73,7 +73,7 @@ jobs:
             target2=$(grep -i ${{ inputs.moduleKeyword }} /tmp/comparisons/target2-go.mod) 
             echo "The versions present in these go.mod files are below" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "- ${ target0 }" >> $GITHUB_STEP_SUMMARY
-            echo "- ${ target1 }" >> $GITHUB_STEP_SUMMARY
-            echo "- ${ target2 }" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target0}" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target1}" >> $GITHUB_STEP_SUMMARY
+            echo "- ${target2}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY 


### PR DESCRIPTION
check various branch go.mod versions for specific keywords comparing across branches quickly

<!-- HTML Comments can be left in place or removed. -->

So this is meant to be a quick github action to compare package versions for some of our issues that can only be verified by comparing go.mod files across release branches. 

A quick how to is to navigate to the distros-test-framework actions tab https://github.com/rancher/distros-test-framework/actions when merged the go-mod-change.yaml action will be present. It is manually configurable and can receive the repository (PRODUCT) you want to check. The default is k3s-io/k3s, you can then pass a minimum of two branches to compare against. This action does a sparse checkout of the repository branches only pulling the go.mod file and greps the file for your targeted package 'kine' for example. Then it will print out the versions in each of your supplied branches at the bottom of the github runs summary. 