### PR TITLE
Add an applyWorkload variable to workload functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ test-version-bump:
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
 	$(if ${DESCRIPTION},-description "${DESCRIPTION}") \
 	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-etcd-bump
@@ -124,7 +125,8 @@ test-etcd-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-runc-bump
@@ -136,7 +138,8 @@ test-runc-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-cilium-bump
@@ -148,7 +151,8 @@ test-cilium-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-canal-bump
@@ -160,7 +164,8 @@ test-canal-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-coredns-bump
@@ -172,7 +177,8 @@ test-coredns-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 
 .PHONY: test-cniplugin-bump
@@ -184,7 +190,8 @@ test-cniplugin-bump:
 	$(if ${CHANNEL},-channel ${CHANNEL}) \
 	$(if ${TEST_CASE},-testCase "${TEST_CASE}") \
 	$(if ${WORKLOAD_NAME},-workloadName ${WORKLOAD_NAME}) \
-	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD})
+	$(if ${DEPLOY_WORKLOAD},-deployWorkload ${DEPLOY_WORKLOAD}) \
+	$(if ${DELETE_WORKLOAD},-deleteWorkload ${DELETE_WORKLOAD})
 
 .PHONY: test-validate-selinux
 test-validate-selinux:

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,6 +146,7 @@ Args:
 - ${TAGTEST}               name of the tag function from suite ( -tags=upgradesuc or -tags=upgrademanual )
 - ${TESTCASE}              name of the testcase to run
 - ${DEPLOYWORKLOAD}        true or false to deploy workload
+- ${DELETEWORKLOAD}        true or false to delete workload that is deployed. Only applicable if DEPLOYWORKLOAD=true
 - ${CMD}                   command to run
 - ${VALUE}                 value to check on host
 - ${INSTALLTYPE}           type of installation (version or commit) + desired value
@@ -188,6 +189,7 @@ VALUE="v1.26.2+k3s1, v0.0.21" " \
 INSTALLTYPE=257fa2c54cda332e42b8aae248c152f4d1898218 \
 TESTCASE=TestLocalPathProvisionerStorage \
 DEPLOYWORKLOAD=true \
+DELETEWORKLOAD=false \
 WORKLOADNAME="someWorkload.yaml"
 ```
 
@@ -207,6 +209,7 @@ $go test -timeout=45m -v -tags=versionbump  ./entrypoint/versionbump/... \
 -installVersionOrCommit INSTALL_K3S_VERSION=v1.27.2+k3s1 \
 -testCase "TestServiceClusterIP, TestLocalPathProvisionerStorage" \
 -deployWorkload true \
+-deleteWorkload false \
 -workloadName "bandwidth-annotations.yaml"
 
  - Logs from test

--- a/docs/version_bump_template.md
+++ b/docs/version_bump_template.md
@@ -23,6 +23,7 @@ Available arguments to create your command with examples:
 - $ -expectedValueUpgrade "v0.0.24"
 - $ -installVersionOrCommit INSTALL_K3S_COMMIT=257fa2c54cda332e42b8aae248c152f4d1898218
 - $ -deployWorkload true
+- $ -deleteWorkload true
 - $ -testCase "TestLocalPathProvisionerStorage"
 - $ -workloadName "bandwidth-annotations.yaml"
 - $ -description "Description of your test"
@@ -45,6 +46,7 @@ go test -timeout=45m -v -tags=versionbump  ./entrypoint/versionbump/... \
 -installVersionOrCommit INSTALL_K3S_VERSION=v1.27.2+k3s1 \
 -testCase "TestServiceClusterIP, TestLocalPathProvisionerStorage" \
 -deployWorkload=true \
+-deleteWorkload=false \
 -workloadName "bandwidth-annotations.yaml"
 ```
 Example of an execution with multiple values on rke2:
@@ -56,6 +58,7 @@ go test -v -timeout=45m -tags=versionbump ./entrypoint/versionbump/... \
 -installVersionOrCommit INSTALL_RKE2_VERSION=v1.25.9+rke2r1 \
 -testCase "TestServiceClusterIP, TestIngress" \
 -deployWorkload true \
+-deleteWorkload true \
 -workloadName "ingress.yaml" \
 -description "Testing ingress and service cluster ip"
 ```

--- a/entrypoint/mixedoscluster/mixedoscluster_test.go
+++ b/entrypoint/mixedoscluster/mixedoscluster_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test: Mixed OS Cluster", func() {
 	})
 
 	It("Validates internode connectivity over the vxlan tunnel", func() {
-		testcase.TestInternodeConnectivityMixedOS(true)
+		testcase.TestInternodeConnectivityMixedOS(true, true)
 	})
 
 	It("Validates cluster by running sonobuoy mixed OS plugin", func() {

--- a/entrypoint/upgradecluster/upgrademanual_test.go
+++ b/entrypoint/upgradecluster/upgrademanual_test.go
@@ -33,33 +33,33 @@ var _ = Describe("Test:", func() {
 		)
 	})
 
-	It("Verifies ClusterIP Service", func() {
-		testcase.TestServiceClusterIp(false)
+	It("Verifies ClusterIP Service pre-upgrade", func() {
+		testcase.TestServiceClusterIp(true, false)
 	})
 
-	It("Verifies NodePort Service", func() {
-		testcase.TestServiceNodePort(false)
+	It("Verifies NodePort Service pre-upgrade", func() {
+		testcase.TestServiceNodePort(true, false)
 	})
 
-	It("Verifies Ingress", func() {
-		testcase.TestIngress(false)
+	It("Verifies Ingress pre-upgrade", func() {
+		testcase.TestIngress(true, false)
 	})
 
-	It("Verifies Daemonset", func() {
-		testcase.TestDaemonset(false)
+	It("Verifies Daemonset pre-upgrade", func() {
+		testcase.TestDaemonset(true, false)
 	})
 
-	It("Verifies dns access", func() {
-		testcase.TestDnsAccess(false)
+	It("Verifies dns access pre-upgrade", func() {
+		testcase.TestDnsAccess(true, false)
 	})
 
 	if cfg.Product == "k3s" {
-		It("Verifies LoadBalancer Service", func() {
-			testcase.TestServiceLoadBalancer(false)
+		It("Verifies LoadBalancer Service pre-upgrade", func() {
+			testcase.TestServiceLoadBalancer(true, false)
 		})
 
-		It("Verifies Local Path Provisioner storage", func() {
-			testcase.TestLocalPathProvisionerStorage(false)
+		It("Verifies Local Path Provisioner storage pre-upgrade", func() {
+			testcase.TestLocalPathProvisionerStorage(true, false)
 		})
 	}
 
@@ -67,14 +67,14 @@ var _ = Describe("Test:", func() {
 		_ = testcase.TestUpgradeClusterManually(customflag.ServiceFlag.InstallMode.String())
 	})
 
-	It("Checks Node Status pos upgrade and validate version", func() {
+	It("Checks Node Status after upgrade and validate version", func() {
 		testcase.TestNodeStatus(
 			assert.NodeAssertReadyStatus(),
 			assert.NodeAssertVersionTypeUpgrade(customflag.ServiceFlag),
 		)
 	})
 
-	It("Checks Pod Status pos upgrade", func() {
+	It("Checks Pod Status after upgrade", func() {
 		testcase.TestPodStatus(
 			assert.PodAssertRestart(),
 			assert.PodAssertReady(),
@@ -83,32 +83,32 @@ var _ = Describe("Test:", func() {
 	})
 
 	It("Verifies ClusterIP Service after upgrade", func() {
-		testcase.TestServiceClusterIp(true)
+		testcase.TestServiceClusterIp(false, true)
 	})
 
 	It("Verifies NodePort Service after upgrade", func() {
-		testcase.TestServiceNodePort(true)
+		testcase.TestServiceNodePort(false, true)
 	})
 
 	It("Verifies Ingress after upgrade", func() {
-		testcase.TestIngress(true)
+		testcase.TestIngress(false, true)
 	})
 
 	It("Verifies Daemonset after upgrade", func() {
-		testcase.TestDaemonset(true)
+		testcase.TestDaemonset(false, true)
 	})
 
 	It("Verifies dns access after upgrade", func() {
-		testcase.TestDnsAccess(true)
+		testcase.TestDnsAccess(false, true)
 	})
 
 	if cfg.Product == "k3s" {
 		It("Verifies LoadBalancer Service after upgrade", func() {
-			testcase.TestServiceLoadBalancer(true)
+			testcase.TestServiceLoadBalancer(false, true)
 		})
 
 		It("Verifies Local Path Provisioner storage after upgrade", func() {
-			testcase.TestLocalPathProvisionerStorage(true)
+			testcase.TestLocalPathProvisionerStorage(false, true)
 		})
 	}
 })

--- a/entrypoint/upgradecluster/upgrademanual_test.go
+++ b/entrypoint/upgradecluster/upgrademanual_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Test:", func() {
 	})
 
 	It("Verifies dns access after upgrade", func() {
-		testcase.TestDnsAccess(false, true)
+		testcase.TestDnsAccess(true, true)
 	})
 
 	if cfg.Product == "k3s" {

--- a/entrypoint/upgradecluster/upgradesuc_test.go
+++ b/entrypoint/upgradecluster/upgradesuc_test.go
@@ -89,7 +89,7 @@ var _ = Describe("SUC Upgrade Tests:", func() {
 	})
 
 	It("Verifies DNS Access post-upgrade", func() {
-		testcase.TestDnsAccess(false, true)
+		testcase.TestDnsAccess(true, true)
 	})
 })
 

--- a/entrypoint/upgradecluster/upgradesuc_test.go
+++ b/entrypoint/upgradecluster/upgradesuc_test.go
@@ -33,24 +33,24 @@ var _ = Describe("SUC Upgrade Tests:", func() {
 		)
 	})
 
-	It("Verifies ClusterIP Service pre upgrade", func() {
-		testcase.TestServiceClusterIp(false)
+	It("Verifies ClusterIP Service pre-upgrade", func() {
+		testcase.TestServiceClusterIp(true, false)
 	})
 
 	It("Verifies NodePort Service pre-upgrade", func() {
-		testcase.TestServiceNodePort(false)
+		testcase.TestServiceNodePort(true, false)
 	})
 
 	It("Verifies Ingress pre-upgrade", func() {
-		testcase.TestIngress(false)
+		testcase.TestIngress(true, false)
 	})
 
 	It("Verifies Daemonset pre-upgrade", func() {
-		testcase.TestDaemonset(false)
+		testcase.TestDaemonset(true, false)
 	})
 
 	It("Verifies DNS Access pre-upgrade", func() {
-		testcase.TestDnsAccess(false)
+		testcase.TestDnsAccess(true, false)
 	})
 
 	It("\nUpgrade via SUC", func() {
@@ -73,23 +73,23 @@ var _ = Describe("SUC Upgrade Tests:", func() {
 	})
 
 	It("Verifies ClusterIP Service post-upgrade", func() {
-		testcase.TestServiceClusterIp(true)
+		testcase.TestServiceClusterIp(false, true)
 	})
 
 	It("Verifies NodePort Service post-upgrade", func() {
-		testcase.TestServiceNodePort(true)
+		testcase.TestServiceNodePort(false, true)
 	})
 
 	It("Verifies Ingress post-upgrade", func() {
-		testcase.TestIngress(true)
+		testcase.TestIngress(false, true)
 	})
 
 	It("Verifies Daemonset post-upgrade", func() {
-		testcase.TestDaemonset(true)
+		testcase.TestDaemonset(false, true)
 	})
 
 	It("Verifies DNS Access post-upgrade", func() {
-		testcase.TestDnsAccess(true)
+		testcase.TestDnsAccess(false, true)
 	})
 })
 

--- a/entrypoint/validatecluster/validatecluster_test.go
+++ b/entrypoint/validatecluster/validatecluster_test.go
@@ -31,32 +31,32 @@ var _ = Describe("Test:", func() {
 	})
 
 	It("Verifies ClusterIP Service", func() {
-		testcase.TestServiceClusterIp(true)
+		testcase.TestServiceClusterIp(true, true)
 	})
 
 	It("Verifies NodePort Service", func() {
-		testcase.TestServiceNodePort(true)
+		testcase.TestServiceNodePort(true, true)
 	})
 
 	It("Verifies Ingress", func() {
-		testcase.TestIngress(true)
+		testcase.TestIngress(true, true)
 	})
 
 	It("Verifies Daemonset", func() {
-		testcase.TestDaemonset(true)
+		testcase.TestDaemonset(true, true)
 	})
 
 	It("Verifies dns access", func() {
-		testcase.TestDnsAccess(true)
+		testcase.TestDnsAccess(true, true)
 	})
 
 	if cfg.Product == "k3s" {
 		It("Verifies Local Path Provisioner storage", func() {
-			testcase.TestLocalPathProvisionerStorage(true)
+			testcase.TestLocalPathProvisionerStorage(true, true)
 		})
 
 		It("Verifies LoadBalancer Service", func() {
-			testcase.TestServiceLoadBalancer(true)
+			testcase.TestServiceLoadBalancer(true, true)
 		})
 	}
 })

--- a/entrypoint/versionbump/canal_test.go
+++ b/entrypoint/versionbump/canal_test.go
@@ -49,6 +49,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/cilium_test.go
+++ b/entrypoint/versionbump/cilium_test.go
@@ -47,6 +47,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/cilium_test.go
+++ b/entrypoint/versionbump/cilium_test.go
@@ -54,23 +54,23 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 	})
 
 	It("Verifies ClusterIP Service", func() {
-		testcase.TestServiceClusterIp(true)
+		testcase.TestServiceClusterIp(true, true)
 	})
 
 	It("Verifies NodePort Service", func() {
-		testcase.TestServiceNodePort(true)
+		testcase.TestServiceNodePort(true, true)
 	})
 
 	It("Verifies Ingress", func() {
-		testcase.TestIngress(true)
+		testcase.TestIngress(true, true)
 	})
 
 	It("Verifies Daemonset", func() {
-		testcase.TestDaemonset(true)
+		testcase.TestDaemonset(true, true)
 	})
 
 	It("Verifies dns access", func() {
-		testcase.TestDnsAccess(true)
+		testcase.TestDnsAccess(true, true)
 	})
 })
 

--- a/entrypoint/versionbump/cniplugin_test.go
+++ b/entrypoint/versionbump/cniplugin_test.go
@@ -46,6 +46,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/coredns.go
+++ b/entrypoint/versionbump/coredns.go
@@ -47,6 +47,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/etcd_test.go
+++ b/entrypoint/versionbump/etcd_test.go
@@ -53,6 +53,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/runc_test.go
+++ b/entrypoint/versionbump/runc_test.go
@@ -51,6 +51,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/entrypoint/versionbump/versionbump_suite_test.go
+++ b/entrypoint/versionbump/versionbump_suite_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	flag.Var(&customflag.TestCaseNameFlag, "testCase", "Comma separated list of test case names to run")
 	flag.StringVar(&customflag.ServiceFlag.TestConfig.WorkloadName, "workloadName", "", "Name of the workload to a standalone deploy")
 	flag.BoolVar(&customflag.ServiceFlag.TestConfig.DeployWorkload, "deployWorkload", false, "Deploy workload customflag for tests passed in")
+	flag.BoolVar(&customflag.ServiceFlag.TestConfig.DeleteWorkload, "deleteWorkload", false, "Delete workload customflag for tests passed in")
 	flag.Var(&customflag.ServiceFlag.ClusterConfig.Destroy, "destroy", "Destroy cluster after test")
 	flag.StringVar(&customflag.ServiceFlag.TestConfig.Description, "description", "", "Description of the test")
 	flag.Parse()

--- a/entrypoint/versionbump/versionbump_test.go
+++ b/entrypoint/versionbump/versionbump_test.go
@@ -47,6 +47,7 @@ var _ = Describe("VersionTemplate Upgrade:", func() {
 			TestConfig: &template.TestConfig{
 				TestFunc:       template.ConvertToTestCase(customflag.ServiceFlag.TestConfig.TestFuncs),
 				DeployWorkload: customflag.ServiceFlag.TestConfig.DeployWorkload,
+				DeleteWorkload: customflag.ServiceFlag.TestConfig.DeleteWorkload,
 				WorkloadName:   customflag.ServiceFlag.TestConfig.WorkloadName,
 			},
 			Description: customflag.ServiceFlag.TestConfig.Description,

--- a/pkg/customflag/model.go
+++ b/pkg/customflag/model.go
@@ -38,6 +38,7 @@ type testConfigFlag struct {
 	TestFuncNames  []string
 	TestFuncs      []TestCaseFlag
 	DeployWorkload bool
+	DeleteWorkload bool
 	WorkloadName   string
 	Description    string
 }
@@ -52,7 +53,7 @@ type clusterConfigFlag struct {
 
 type destroyFlag bool
 
-type TestCaseFlag func(deployWorkload bool)
+type TestCaseFlag func(applyWorkload, deleteWorkload bool)
 
 type stringSlice []string
 

--- a/pkg/template/helper.go
+++ b/pkg/template/helper.go
@@ -69,13 +69,12 @@ func AddTestCases(names []string) ([]testCase, error) {
 		"TestLocalPathProvisionerStorage":  testcase.TestLocalPathProvisionerStorage,
 		"TestServiceLoadBalancer":          testcase.TestServiceLoadBalancer,
 		"TestInternodeConnectivityMixedOS": testcase.TestInternodeConnectivityMixedOS,
-		"TestSonobuoyMixedOS":              testcase.TestSonobuoyMixedOS,
 	}
 
 	for _, name := range names {
 		name = strings.TrimSpace(name)
 		if name == "" {
-			testCases = append(testCases, func(deployWorkload bool) {})
+			testCases = append(testCases, func(applyWorkload, deleteWorkload bool) {})
 		} else if test, ok := tcs[name]; ok {
 			testCases = append(testCases, test)
 		} else {

--- a/pkg/template/model.go
+++ b/pkg/template/model.go
@@ -30,16 +30,17 @@ type TestMap struct {
 type TestConfig struct {
 	TestFunc       []testCase
 	DeployWorkload bool
+	DeleteWorkload bool
 	WorkloadName   string
 }
 
 // testCase is a custom type representing the test function.
-type testCase func(deployWorkload bool)
+type testCase func(applyWorkload, deleteWorkload bool)
 
 // testCaseWrapper wraps a test function and calls it with the given GinkgoTInterface and VersionTestTemplate.
 func testCaseWrapper(v VersionTestTemplate) {
 	for _, testFunc := range v.TestConfig.TestFunc {
-		testFunc(v.TestConfig.DeployWorkload)
+		testFunc(v.TestConfig.DeployWorkload, v.TestConfig.DeleteWorkload)
 	}
 }
 

--- a/pkg/testcase/daemonset.go
+++ b/pkg/testcase/daemonset.go
@@ -11,9 +11,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDaemonset(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "daemonset.yaml")
-	Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
+func TestDaemonset(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "daemonset.yaml")
+		Expect(err).NotTo(HaveOccurred(), "Daemonset manifest not deployed")
+	}
 
 	pods, _ := shared.GetPods(false)
 

--- a/pkg/testcase/ingressdns.go
+++ b/pkg/testcase/ingressdns.go
@@ -12,13 +12,15 @@ const (
 	nslookup      = "kubernetes.default.svc.cluster.local"
 )
 
-func TestIngress(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "ingress.yaml")
-	Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
+func TestIngress(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "ingress.yaml")
+		Expect(err).NotTo(HaveOccurred(), "Ingress manifest not deployed")
+	}
 
 	getIngressRunning := "kubectl get pods -n test-ingress -l k8s-app=nginx-app-ingress" +
 		" --field-selector=status.phase=Running  --kubeconfig="
-	err = assert.ValidateOnHost(getIngressRunning+shared.KubeConfigFile, statusRunning)
+	err := assert.ValidateOnHost(getIngressRunning+shared.KubeConfigFile, statusRunning)
 	Expect(err).NotTo(HaveOccurred(), err)
 
 	ingressIps, err := shared.FetchIngressIP("test-ingress")
@@ -39,12 +41,14 @@ func TestIngress(deleteWorkload bool) {
 	}
 }
 
-func TestDnsAccess(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "dnsutils.yaml")
-	Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
+func TestDnsAccess(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "dnsutils.yaml")
+		Expect(err).NotTo(HaveOccurred(), "dnsutils manifest not deployed")
+	}
 
 	getPodDnsUtils := "kubectl get pods -n dnsutils dnsutils  --kubeconfig="
-	err = assert.ValidateOnHost(getPodDnsUtils+shared.KubeConfigFile, statusRunning)
+	err := assert.ValidateOnHost(getPodDnsUtils+shared.KubeConfigFile, statusRunning)
 	Expect(err).NotTo(HaveOccurred(), err)
 
 	execDnsUtils := "kubectl exec -n dnsutils -t dnsutils --kubeconfig="

--- a/pkg/testcase/localpathstorage.go
+++ b/pkg/testcase/localpathstorage.go
@@ -12,13 +12,15 @@ import (
 
 var lps = "local-path-storage"
 
-func TestLocalPathProvisionerStorage(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "local-path-provisioner.yaml")
-	Expect(err).NotTo(HaveOccurred(), "local-path-provisioner manifest not deployed")
+func TestLocalPathProvisionerStorage(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "local-path-provisioner.yaml")
+		Expect(err).NotTo(HaveOccurred(), "local-path-provisioner manifest not deployed")
+	}
 
 	getPodVolumeTestRunning := "kubectl get pods -n local-path-storage" +
 		" --field-selector=status.phase=Running --kubeconfig=" + shared.KubeConfigFile
-	err = assert.ValidateOnHost(
+	err := assert.ValidateOnHost(
 		getPodVolumeTestRunning,
 		statusRunning,
 	)

--- a/pkg/testcase/networkconnectivity.go
+++ b/pkg/testcase/networkconnectivity.go
@@ -12,14 +12,16 @@ import (
 
 // TestInternodeConnectivityMixedOS Deploys services in the cluster
 // and validates communication between linux and windows nodes
-func TestInternodeConnectivityMixedOS(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply",
-		"pod_client.yaml", "windows_app_deployment.yaml")
-	Expect(err).NotTo(HaveOccurred())
+func TestInternodeConnectivityMixedOS(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply",
+			"pod_client.yaml", "windows_app_deployment.yaml")
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	assert.ValidatePodIPByLabel([]string{"app=client", "app=windows-app"}, []string{"10.42", "10.42"})
 
-	err = testCrossNodeService(
+	err := testCrossNodeService(
 		[]string{"client-curl", "windows-app-svc"},
 		[]string{"8080", "3000"},
 		[]string{"Welcome to nginx", "Welcome to PSTools"})

--- a/pkg/testcase/node.go
+++ b/pkg/testcase/node.go
@@ -36,7 +36,7 @@ func TestNodeStatus(
 				nodeAssertVersion(g, node)
 			}
 		}
-	}, "1500s", "20s").Should(Succeed())
+	}, "2100s", "20s").Should(Succeed())
 
 	fmt.Println("\n\nCluster nodes:")
 	_, err := shared.GetNodes(true)

--- a/pkg/testcase/service.go
+++ b/pkg/testcase/service.go
@@ -7,13 +7,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestServiceClusterIp(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "clusterip.yaml")
-	Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
+func TestServiceClusterIp(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "clusterip.yaml")
+		Expect(err).NotTo(HaveOccurred(), "Cluster IP manifest not deployed")
+	}
 
 	getClusterIP := "kubectl get pods -n test-clusterip -l k8s-app=nginx-app-clusterip " +
 		"--field-selector=status.phase=Running --kubeconfig="
-	err = assert.ValidateOnHost(getClusterIP+shared.KubeConfigFile, statusRunning)
+	err := assert.ValidateOnHost(getClusterIP+shared.KubeConfigFile, statusRunning)
 	Expect(err).NotTo(HaveOccurred(), err)
 
 	clusterip, port, _ := shared.FetchClusterIP("test-clusterip", "nginx-clusterip-svc")
@@ -30,9 +32,11 @@ func TestServiceClusterIp(deleteWorkload bool) {
 	}
 }
 
-func TestServiceNodePort(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "nodeport.yaml")
-	Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
+func TestServiceNodePort(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "nodeport.yaml")
+		Expect(err).NotTo(HaveOccurred(), "NodePort manifest not deployed")
+	}
 
 	nodeExternalIP := shared.FetchNodeExternalIP()
 	nodeport, err := shared.FetchServiceNodePort("test-nodeport", "nginx-nodeport-svc")
@@ -60,9 +64,11 @@ func TestServiceNodePort(deleteWorkload bool) {
 	}
 }
 
-func TestServiceLoadBalancer(deleteWorkload bool) {
-	_, err := shared.ManageWorkload("apply", "loadbalancer.yaml")
-	Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
+func TestServiceLoadBalancer(applyWorkload, deleteWorkload bool) {
+	if applyWorkload {
+		_, err := shared.ManageWorkload("apply", "loadbalancer.yaml")
+		Expect(err).NotTo(HaveOccurred(), "Loadbalancer manifest not deployed")
+	}
 
 	getLoadbalancerSVC := "kubectl get service -n test-loadbalancer nginx-loadbalancer-svc" +
 		" --output jsonpath={.spec.ports[0].port} --kubeconfig="

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -36,6 +36,7 @@ if [ -n "${TEST_DIR}" ]; then
             -channel "${CHANNEL}" \
             -testCase "${TEST_CASE}" \
             -deployWorkload "${DEPLOY_WORKLOAD}" \
+            -deleteWorkload "${DELETE_WORKLOAD}" \
             -workloadName "${WORKLOAD_NAME}" \
             -description "${DESCRIPTION}"
     elif [ "${TEST_DIR}" = "mixedoscluster" ]; then


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
This adds another variable to the functions that deal with workloads. This new variable controls whether or not to apply the workload. Without this, we could have false positives in cases where we want tests that had previously deployed a workload to ensure that workload still exists.

These changes also brought to light a flag, `deployWorkload`, that is used in version bump tests. This actually was more of a `deleteWorkload` flag, but now we have both deploy and delete as part of these changes.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->
Fix and refactor

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.
Jenkins jobs run for SUC Upgrade and etcd version bump available upon request.

2. Verify code lint; we should not have errors.


3. Update the documentation if needed.


4. Update makefile and docker run if adding new tests.


5. Run your tests at least 4 times with all configurations needed and possible.


6. If needed test with different os types.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->
Hackweek!

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
In the case of the DNS tests, the workload is just a pod. Therefore, it should be deleted during upgrade, so I am still applying the workload post upgrade.
