### PR TITLE
Use regex to parse pods on multiple spaces

### DIFF
--- a/shared/cluster.go
+++ b/shared/cluster.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -371,7 +372,7 @@ func parsePods(res string) []Pod {
 
 	for _, rec := range podList {
 		offset := 0
-		fields := strings.Fields(rec)
+		fields := regexp.MustCompile(`\s{2,}`).Split(rec, -1)
 		if strings.TrimSpace(rec) == "" || len(fields) < 9 {
 			continue
 		}
@@ -383,7 +384,7 @@ func parsePods(res string) []Pod {
 		p.Name = fields[offset]
 		p.Ready = fields[offset+1]
 		p.Status = fields[offset+2]
-		p.Restarts = fields[offset+3]
+		p.Restarts = regexp.MustCompile(`\([^\)]+\)`).Split(fields[offset+3], -1)[0]
 		p.Age = fields[offset+4]
 		p.NodeIP = fields[offset+5]
 		p.Node = fields[offset+6]


### PR DESCRIPTION
#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Instead of using `strings.Fields` to parse the pods, which parses based off a single whitespace, this is using a regex that parses based off 2 or more spaces. I'm not 100% sure if there's ever less than 2 spaces, but in my tests I found this to work consistently.

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->
bugfix

#### Testing ####
<!-- Answer the checklist bellow  -->
I tested locally a few times using the certrotate job in rke2, where this was consistently reproducible.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
