### PR TITLE
fix logger call

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"sync"
 
@@ -14,41 +13,45 @@ var (
 	le   *log.Entry
 )
 
-func AddLogger(json bool) *log.Entry {
+func AddLogger() *log.Entry {
 	once.Do(func() {
-		logger := newLogger(json)
+		logger := newLogger()
 		le = log.NewEntry(logger)
 	})
 
 	return le
 }
 
-func newLogger(json bool) *log.Logger {
+func newLogger() *log.Logger {
 	logger := log.New()
+	logger.SetFormatter(customFormatter())
+	logger.SetReportCaller(true)
+	logger.SetLevel(log.DebugLevel)
 
-	if !json {
-		logger.SetFormatter(&log.TextFormatter{
+	return logger
+}
+
+func customFormatter() *log.TextFormatter {
+	if log.GetLevel() == log.DebugLevel || log.GetLevel() == log.InfoLevel {
+		return &log.TextFormatter{
 			ForceColors:   true,
 			FullTimestamp: true,
 			CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-				link := fmt.Sprintf("%s:%d", f.File, f.Line)
-				return f.Function, link
+				return "", ""
 			},
 			QuoteEmptyFields: true,
-		})
-	} else {
-		logger.SetFormatter(&log.JSONFormatter{
+		}
+	} else if log.GetLevel() == log.WarnLevel || log.GetLevel() == log.ErrorLevel ||
+		log.GetLevel() == log.FatalLevel || log.GetLevel() == log.PanicLevel {
+		return &log.TextFormatter{
+			ForceColors:   true,
+			FullTimestamp: true,
 			CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-				link := fmt.Sprintf("file://%s:%d", f.File, f.Line)
-				return f.Function, link
+				return fmt.Sprintf("%s:%d", f.File, f.Line), ""
 			},
-			PrettyPrint: true,
-		})
+			QuoteEmptyFields: true,
+		}
 	}
 
-	logger.SetReportCaller(true)
-	logger.SetLevel(log.DebugLevel)
-	logger.Out = os.Stdout
-
-	return logger
+	return nil
 }

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -249,14 +249,16 @@ func GetJournalLogs(level, ip string) string {
 
 // ReturnLogError logs the error and returns it.
 func ReturnLogError(format string, args ...interface{}) error {
-	log := logger.AddLogger(false)
+	log := logger.AddLogger()
 	err := formatLogArgs(format, args...)
 
 	if err != nil {
 		pc, file, line, ok := runtime.Caller(1)
 		if ok {
 			funcName := runtime.FuncForPC(pc).Name()
-			log.Error(fmt.Sprintf("%s\nLast call: %s in %s:%d", err.Error(), funcName, file, line))
+
+			formattedPath := fmt.Sprintf("file:%s:%d", file, line)
+			log.Error(fmt.Sprintf("%s\nLast call: %s in %s", err.Error(), funcName, formattedPath))
 		} else {
 			log.Error(err.Error())
 		}
@@ -267,7 +269,7 @@ func ReturnLogError(format string, args ...interface{}) error {
 
 // LogLevel logs the message with the specified level.
 func LogLevel(level, format string, args ...interface{}) {
-	log := logger.AddLogger(false)
+	log := logger.AddLogger()
 	msg := formatLogArgs(format, args...)
 
 	switch level {


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

- change logger to only log call stack when level is not INFO or DEBUG
![Screenshot 2023-12-14 at 10 23 55](https://github.com/rancher/distros-test-framework/assets/124721967/c90ff27e-0123-4481-b441-38fd6ac15267)
![Screenshot 2023-12-14 at 10 43 10](https://github.com/rancher/distros-test-framework/assets/124721967/3f2be5d0-b9e9-45a1-b468-aa5e48e26a5b)


- fix return log error to add link to error it self


<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.


2. Verify code lint; we should not have errors.


3. Update the documentation if needed.


4. Update makefile and docker run if adding new tests.


5. Run your tests at least 4 times with all configurations needed and possible.


6. If needed test with different os types.


#### Linked Issues ####
 
<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
![Screenshot 2023-12-14 at 10 43 14](https://github.com/rancher/distros-test-framework/assets/124721967/31f3b782-1fc8-4ca6-a0fe-ae76868f476d)



