### PR TITLE
remove client-supervisor certs from identical files

### DIFF
--- a/pkg/testcase/certrotate.go
+++ b/pkg/testcase/certrotate.go
@@ -45,7 +45,6 @@ func certRotate(product string, ips []string) {
 func verifyIdenticalFiles(identicalFileList string) {
 	expectedFileList := []string{
 		"client-ca.crt", "client-ca.key", "client-ca.nochain.crt",
-		"client-supervisor.crt", "client-supervisor.key",
 		"peer-ca.crt", "peer-ca.key",
 		"server-ca.crt", "server-ca.key",
 		"request-header-ca.crt", "request-header-ca.key",


### PR DESCRIPTION
client-supervisor certs are added to rotate list. Updated test to reflect the change