### PR TITLE
Fix for split-role SUC and edge case around binary location

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -430,7 +430,7 @@ func checkFiles(product string, paths []string, scriptName string, ip string) (s
 }
 
 func FindPath(name, ip string) (string, error) {
-	searchPath := fmt.Sprintf("find / -type f -executable -name %s 2>/dev/null | sed 1q", name)
+	searchPath := fmt.Sprintf("find / -type f -executable -name %s 2>/dev/null | grep -v data | sed 1q", name)
 	fullPath, err := RunCommandOnNode(searchPath, ip)
 	if err != nil {
 		return "", err

--- a/workloads/amd64/suc.yaml
+++ b/workloads/amd64/suc.yaml
@@ -65,12 +65,12 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - {key: "node-role.kubernetes.io/master", operator: In, values: ["true"]}
+                  - {key: node-role.kubernetes.io/control-plane, operator: In, values: ["true"]}
       serviceAccountName: system-upgrade
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
-        - key: "node-role.kubernetes.io/master"
+        - key: "node-role.kubernetes.io/control-plane"
           operator: "Exists"
           effect: "NoSchedule"
       containers:


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Two fixes:
1. split-role SUC does not have a `master` role. Both split-role and standard have the `control-plane` role, so this should be used instead.
2. There is an edge case where sometimes the data-dir binary file will be returned first instead of the /usr/... file. This causes failures during at least cluster-reset, so it should be ignored when retrieving the file.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->
Fix

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.
N/A

2. Verify code lint; we should not have errors.
✅ 

3. Update the documentation if needed.
N/A

4. Update makefile and docker run if adding new tests.
N/A

5. Run your tests at least 4 times with all configurations needed and possible.
Ran cluster-reset, create, validate, and suc upgrade.

6. If needed test with different os types.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->
N/A

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
