### PR TITLE
replace hardcoded rke2 to product var instead

### DIFF
--- a/pkg/testcase/upgradenodereplacement.go
+++ b/pkg/testcase/upgradenodereplacement.go
@@ -45,7 +45,7 @@ func TestUpgradeReplaceNode(cluster *shared.Cluster, version string) {
 	Expect(scpErr).NotTo(HaveOccurred(), scpErr)
 	shared.LogLevel("info", "Scp files to new server nodes done\n")
 
-	serverLeaderIP := cluster.ServerIPs[0]
+	serverLeaderIP := newExternalServerIps[0]
 	token, err := shared.FetchToken(cluster.Config.Product, serverLeaderIP)
 	Expect(err).NotTo(HaveOccurred(), err)
 

--- a/pkg/testcase/upgradenodereplacement.go
+++ b/pkg/testcase/upgradenodereplacement.go
@@ -46,7 +46,7 @@ func TestUpgradeReplaceNode(cluster *shared.Cluster, version string) {
 	shared.LogLevel("info", "Scp files to new server nodes done\n")
 
 	serverLeaderIP := cluster.ServerIPs[0]
-	token, err := shared.FetchToken(serverLeaderIP)
+	token, err := shared.FetchToken(cluster.Config.Product, serverLeaderIP)
 	Expect(err).NotTo(HaveOccurred(), err)
 
 	serverErr := nodeReplaceServers(

--- a/pkg/testcase/upgradenodereplacement.go
+++ b/pkg/testcase/upgradenodereplacement.go
@@ -45,7 +45,7 @@ func TestUpgradeReplaceNode(cluster *shared.Cluster, version string) {
 	Expect(scpErr).NotTo(HaveOccurred(), scpErr)
 	shared.LogLevel("info", "Scp files to new server nodes done\n")
 
-	serverLeaderIP := newExternalServerIps[0]
+	serverLeaderIP := cluster.ServerIPs[0]
 	token, err := shared.FetchToken(cluster.Config.Product, serverLeaderIP)
 	Expect(err).NotTo(HaveOccurred(), err)
 

--- a/shared/cluster.go
+++ b/shared/cluster.go
@@ -591,8 +591,8 @@ func GetNodeNameByIP(ip string) (string, error) {
 	}
 }
 
-func FetchToken(ip string) (string, error) {
-	token, err := RunCommandOnNode("sudo cat  /var/lib/rancher/rke2/server/node-token", ip)
+func FetchToken(product, ip string) (string, error) {
+	token, err := RunCommandOnNode(fmt.Sprintf("sudo cat /var/lib/rancher/%s/server/node-token", product), ip)
 	if err != nil {
 		return "", ReturnLogError("failed to fetch token: %w\n", err)
 	}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Upgrade Node replacement test fails today while looking up FetchToken since it has rke2 hardcoded. 
Updating FetchToken to have product arg and updated the call to the method as well. 

<!-- Does this change require an update to documentation? -->
No

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.


2. Verify code lint; we should not have errors.


3. Update the documentation if needed.


4. Update makefile and docker run if adding new tests.


5. Run your tests at least 4 times with all configurations needed and possible.


6. If needed test with different os types.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
