### PR TITLE
renaming the subindex for the splitroles batch job

### DIFF
--- a/scripts/Jenkinsfile_batch_install_test
+++ b/scripts/Jenkinsfile_batch_install_test
@@ -88,7 +88,7 @@ node {
                   break             
                 case "restartservice":
                   jobs[test_name] = { build job: "${env.PRODUCT_NAME}_restart_service", parameters: install_params }
-                  jobs[test_name] = { build job: "${env.PRODUCT_NAME}_restart_service_splitroles", parameters: install_params }
+                  jobs["restartservice_splitroles"] = { build job: "${env.PRODUCT_NAME}_restart_service_splitroles", parameters: install_params }
                   break
                 case "rebootinstances":
                   jobs[test_name] = { build job: "${env.PRODUCT_NAME}_reboot_instances", parameters: install_params }

--- a/scripts/Jenkinsfile_batch_upgrade_test
+++ b/scripts/Jenkinsfile_batch_upgrade_test
@@ -94,7 +94,7 @@ node {
                   break
                 case "upgradesuc": 
                   jobs[test_name] = { build job: "${env.PRODUCT_NAME}_suc_upgrade", parameters: upgrade_params }
-                  jobs[test_name] = { build job: "${env.PRODUCT_NAME}_suc_upgrade_splitroles", parameters: upgrade_params }
+                  jobs["upgradesuc_splitroles"] = { build job: "${env.PRODUCT_NAME}_suc_upgrade_splitroles", parameters: upgrade_params }
                   break
                 case "upgradereplacement": 
                   jobs[test_name] = { build job: "${env.PRODUCT_NAME}_upgrade_node_replacement", parameters: upgrade_params }


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
for restart service and suc upgrade, renaming the subindex to 
jobs["restartservice_splitroles"]
jobs["upgradesuc_splitroles"]
so the job call doesnt get overwritten. 
<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.


2. Verify code lint; we should not have errors.


3. Update the documentation if needed.


4. Update makefile and docker run if adding new tests.


5. Run your tests at least 4 times with all configurations needed and possible.


6. If needed test with different os types.


#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
