### PR TITLE
update image to avoid rate limit

### DIFF
--- a/workloads/amd64/local-path-provisioner.yaml
+++ b/workloads/amd64/local-path-provisioner.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: volume-test
-          image: nginx:stable-alpine
+          image: rancher/mirrored-library-nginx:1.27.2-alpine
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: volv

--- a/workloads/arm/local-path-provisioner.yaml
+++ b/workloads/arm/local-path-provisioner.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: volume-test
-          image: nginx:stable-alpine
+          image: rancher/mirrored-library-nginx:1.27.2-alpine
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: volv


### PR DESCRIPTION
This PR is to update image  for local-path-provisioner test from rancher/mirrored-xxx so that it does not get rate limited