### PR TITLE
Fix support uc os image

### DIFF
--- a/scripts/install_sonobuoy.sh
+++ b/scripts/install_sonobuoy.sh
@@ -22,15 +22,24 @@ get_binpath(){
     # Default location for root user
     binpath=/usr/local/bin
 
-    # Check if /usr/local/bin is on a read-pnly filesystem, use ~/bin if so
-    realdir=$(findmnt -n -o SOURCE --target ${binpath})
+    # Check if /usr/local/bin is on a read-only filesystem, use ~/bin if so
+    realdir=$(findmnt -n -o SOURCE --target "${binpath}")
 
     # This line is mainly here to support LVM-based configuration
     realdir=$(sed 's/.*\[\/@\(.*\)\]/\1/' <<<${realdir})
+    if [[ -z "${realdir}" ]]; then
+      echo "ERROR: cannot find local /bin directory!"
+      exit 1
+    fi
 
-	# Use "homed" bin location if /usr is read-only
+    # Use "homed" bin location if /usr is read-only
     mountperm=$(findmnt -n -o OPTIONS ${realdir} | cut -d, -f1)
-    [[ "${mountperm}" == "ro" ]] && binpath=~/bin
+    if [[ -z "${mountperm}" ]]; then
+      echo "ERROR: cannot get permissions of ${realdir} directory!"
+      exit 1
+    elif [[ "${mountperm}" == "ro" ]]; then
+      binpath=~/bin
+    fi
   fi
 
   # To be sure that the path is available (it does not hurt to do it)
@@ -87,8 +96,9 @@ installation(){
     fi
     tar -xvf sonobuoy.tar.gz
     wait
-    mv sonobuoy $(get_binpath)/sonobuoy
-    chmod +x $(get_binpath)/sonobuoy
+    binpath=$(get_binpath)
+    mv sonobuoy ${binpath}/sonobuoy
+    chmod +x ${binpath}/sonobuoy
     rm -f sonobuoy_checksums.txt
 }
 

--- a/scripts/install_sonobuoy.sh
+++ b/scripts/install_sonobuoy.sh
@@ -13,6 +13,32 @@ max_retries=5
 retry_delay=11
 # adopt golang error handling in bash check variables are passed in appropriately - if not return appropriate error message
 
+get_binpath(){
+  # Default location for non-root user
+  binpath=~/bin
+
+  # /usr/local/bin is only accessible if we are root
+  if (( $(id -u) == 0 )); then
+    # Default location for root user
+    binpath=/usr/local/bin
+
+    # Check if /usr/local/bin is on a read-pnly filesystem, use ~/bin if so
+    realdir=$(findmnt -n -o SOURCE --target ${binpath})
+
+    # This line is mainly here to support LVM-based configuration
+    realdir=$(sed 's/.*\[\/@\(.*\)\]/\1/' <<<${realdir})
+
+	# Use "homed" bin location if /usr is read-only
+    mountperm=$(findmnt -n -o OPTIONS ${realdir} | cut -d, -f1)
+    [[ "${mountperm}" == "ro" ]] && binpath=~/bin
+  fi
+
+  # To be sure that the path is available (it does not hurt to do it)
+  mkdir -p ${binpath}
+
+  echo ${binpath}
+}
+
 download_retry(){
   i=1
 
@@ -61,8 +87,8 @@ installation(){
     fi
     tar -xvf sonobuoy.tar.gz
     wait
-    mv sonobuoy /usr/local/bin/sonobuoy
-    chmod +x /usr/local/bin/sonobuoy
+    mv sonobuoy $(get_binpath)/sonobuoy
+    chmod +x $(get_binpath)/sonobuoy
     rm -f sonobuoy_checksums.txt
 }
 
@@ -70,7 +96,7 @@ deletion(){
     echo "Deleting sonobuoy installer"
     rm -rf my-sonobuoy-plugins
     rm -rf sonobuoy_*
-    rm -rf /usr/local/bin/sonobuoy
+    rm -rf $(get_binpath)/sonobuoy
 }
 
 if [ "$action" == "install" ];

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -402,15 +402,7 @@ func fileExists(files []os.DirEntry, workload string) bool {
 	return false
 }
 
-func FindPath(name, ip string) (string, error) {
-	if ip == "" {
-		return "", errors.New("ip should not be empty")
-	}
-
-	if name == "" {
-		return "", errors.New("name should not be empty")
-	}
-
+func getCommonPaths(ip string) (string, error) {
 	// get home directory on node
 	homedir, err := RunCommandOnNode("echo ~", ip)
 	if err != nil || homedir == "" {
@@ -429,6 +421,24 @@ func FindPath(name, ip string) (string, error) {
 		"/usr/local/bin:" +
 		"/usr/bin:" +
 		homedir + "/bin:"
+
+	return commonPaths, nil
+}
+
+func FindPath(name, ip string) (string, error) {
+	if ip == "" {
+		return "", errors.New("ip should not be empty")
+	}
+
+	if name == "" {
+		return "", errors.New("name should not be empty")
+	}
+
+	// get needed common paths
+	commonPaths, err := getCommonPaths(ip)
+	if err != nil {
+		return "", fmt.Errorf("failed to get common paths: %w", err)
+	}
 
 	// adding the common paths to the PATH environment variable by sourcing it from a file.
 	envFile := "find_path_env.sh"

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -224,12 +224,15 @@ func InstallHelm() (res string, err error) {
 		return "", ReturnLogError("failed to get home dir: %w", err)
 	}
 
+	// get targeted architecture
+	arch := os.Getenv("arch")
+
 	// install Helm from local tarball
 	cmd := fmt.Sprintf("mkdir -p %v/bin && "+
-		"tar -zxvf %v/bin/helm-v3.18.3-linux-amd64.tar.gz -C /tmp && "+
-		"cp /tmp/linux-amd64/helm %v/bin/helm && "+
+		"tar -zxvf %v/bin/helm-v*-linux-%v*.tar.gz -C /tmp && "+
+		"cp /tmp/linux-%v*/helm %v/bin/helm && "+
 		"chmod +x %v/bin/helm && "+
-		"helm version", homedir, BasePath(), homedir, homedir)
+		"helm version", homedir, BasePath(), arch, arch, homedir, homedir)
 
 	return RunCommandHost(cmd)
 }

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -226,13 +226,26 @@ func InstallHelm() (res string, err error) {
 
 	// get targeted architecture
 	arch := os.Getenv("arch")
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+
+	switch arch {
+	case "x86_64":
+		arch = "amd64"
+	case "amd64", "arm64":
+		// Supported as-is
+	default:
+		return "", ReturnLogError("unsupported architecture for Helm installation: %q", arch)
+	}
 
 	// install Helm from local tarball
-	cmd := fmt.Sprintf("mkdir -p %v/bin && "+
+	localbin := fmt.Sprintf("%v/bin", homedir)
+	cmd := fmt.Sprintf("mkdir -p %v && "+
 		"tar -zxvf %v/bin/helm-v*-linux-%v*.tar.gz -C /tmp && "+
-		"cp /tmp/linux-%v*/helm %v/bin/helm && "+
-		"chmod +x %v/bin/helm && "+
-		"helm version", homedir, BasePath(), arch, arch, homedir, homedir)
+		"cp /tmp/linux-%v*/helm %v/helm && "+
+		"chmod +x %v/helm && "+
+		"%v/helm version", localbin, BasePath(), arch, arch, localbin, localbin, localbin)
 
 	return RunCommandHost(cmd)
 }
@@ -404,9 +417,13 @@ func fileExists(files []os.DirEntry, workload string) bool {
 
 func getCommonPaths(ip string) (string, error) {
 	// get home directory on node
-	homedir, err := RunCommandOnNode("echo ~", ip)
-	if err != nil || homedir == "" {
+	homedir, err := RunCommandOnNode(`echo "$HOME"`, ip)
+	if err != nil {
 		return "", ReturnLogError("failed to get home dir: %w", err)
+	}
+	homedir = strings.TrimSpace(homedir)
+	if homedir == "" {
+		return "", ReturnLogError("failed to get home dir: HOME is empty")
 	}
 
 	// adding common paths to the environment variable PATH since in some os's not all paths are available.

--- a/shared/aux.go
+++ b/shared/aux.go
@@ -218,11 +218,18 @@ func prepareScpKey(src string) (string, error) {
 
 // InstallHelm installs helm on the container.
 func InstallHelm() (res string, err error) {
-	// Install Helm from local tarball
-	cmd := fmt.Sprintf("tar -zxvf %v/bin/helm-v3.18.3-linux-amd64.tar.gz -C /tmp && "+
-		"cp /tmp/linux-amd64/helm /usr/local/bin/helm && "+
-		"chmod +x /usr/local/bin/helm && "+
-		"helm version", BasePath())
+	// get home directory
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return "", ReturnLogError("failed to get home dir: %w", err)
+	}
+
+	// install Helm from local tarball
+	cmd := fmt.Sprintf("mkdir -p %v/bin && "+
+		"tar -zxvf %v/bin/helm-v3.18.3-linux-amd64.tar.gz -C /tmp && "+
+		"cp /tmp/linux-amd64/helm %v/bin/helm && "+
+		"chmod +x %v/bin/helm && "+
+		"helm version", homedir, BasePath(), homedir, homedir)
 
 	return RunCommandHost(cmd)
 }
@@ -401,6 +408,12 @@ func FindPath(name, ip string) (string, error) {
 		return "", errors.New("name should not be empty")
 	}
 
+	// get home directory on node
+	homedir, err := RunCommandOnNode("echo ~", ip)
+	if err != nil || homedir == "" {
+		return "", ReturnLogError("failed to get home dir: %w", err)
+	}
+
 	// adding common paths to the environment variable PATH since in some os's not all paths are available.
 	commonPaths := "/var/lib/rancher/rke2/bin:" +
 		"/var/rancher/rke2/bin:" +
@@ -411,11 +424,12 @@ func FindPath(name, ip string) (string, error) {
 		"/var/rancher/k3s/bin:" +
 		"/opt/k3s/bin:" +
 		"/usr/local/bin:" +
-		"/usr/bin:"
+		"/usr/bin:" +
+		homedir + "/bin:"
 
 	// adding the common paths to the PATH environment variable by sourcing it from a file.
 	envFile := "find_path_env.sh"
-	err := ExportEnvProfileNode([]string{ip}, map[string]string{"PATH": commonPaths}, envFile)
+	err = ExportEnvProfileNode([]string{ip}, map[string]string{"PATH": commonPaths}, envFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to create environment file: %w", err)
 	}

--- a/shared/clusterconfig.go
+++ b/shared/clusterconfig.go
@@ -240,6 +240,7 @@ func addClusterFromKubeConfig(nodes []Node) (*Cluster, error) {
 		AgentIPs:   agentIPs,
 		NumAgents:  len(agentIPs),
 		NumServers: len(serverIPs),
+		FQDN:       os.Getenv("FQDN"),
 		Aws: AwsConfig{
 			Region:           os.Getenv("region"),
 			Subnets:          os.Getenv("subnets"),


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR adds some modifications to allow `distros-test-framework` to be embedded inside  the openQA tests for [Elemental3](https://www.github.com/suse/elemental) (aka. UnifiedCore).

This has been discussed by email with @ShylajaDevadiga.

<!-- Does this change require an update to documentation? -->

#### Types of Changes ####

<!-- What types of changes does your code introduce to distro framework? Issue validation, Patch Validation, Fix, New functionality, Refactor or etc -->

The big change is the ability to move `sonobuoy` to another directory than `/usr/local/bin`, but this one will remain the default, to avoid impacts on your side. Same for `helm` installation. This is because `/usr/local` is not writable in our immutable OS image.

#### Testing ####
<!-- Answer the checklist bellow  -->

Checklist:
1. If your PR changes anything on or related to Jenkins, run it pointing to your branch to make sure it's okay.

N/A

2. Verify code lint; we should not have errors.

OK

3. Update the documentation if needed.

N/A

4. Update makefile and docker run if adding new tests.

N/A

5. Run your tests at least 4 times with all configurations needed and possible.

OK

6. If needed test with different os types.

N/A

#### Linked Issues ####

<!-- Link any related issues, pull-requests, qa-tasks repo issues or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/rancher/distros-test-framework/issues . -->

N/A

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

You can see an openQA test with the framework used: https://openqa.suse.de/tests/20005099 (internal VPN needed, no user/password needed to see the results).